### PR TITLE
feat: Configure environment variables and fix dev server

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+# Neon Auth environment variables for Next.js
+NEXT_PUBLIC_STACK_PROJECT_ID='75ed08cf-bcb7-4e41-bac8-eea610fccc41'
+NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY='pck_xzx3tck9nae8vd94b35db8jh54jg3cgq6m9d003xggx4g'
+STACK_SECRET_SERVER_KEY='ssk_qhrn4zts3s0w5kdtw8drtrk4dc1xxx62wy0pgyj5sz170'
+
+# Database owner connection string
+DATABASE_URL='postgresql://neondb_owner:npg_y6BfmOo5vdjE@ep-broad-snow-adpw07mh-pooler.c-2.us-east-1.aws.neon.tech/neondb?sslmode=require'

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.2.2",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4303,6 +4304,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "NODE_ENV=development tsx --env-file .env server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
- Adds a `.env` file to store environment variables for the database connection and Neon Auth.
- Updates the `dev` script in `package.json` to use the `tsx --env-file` flag. This ensures that the environment variables from the `.env` file are loaded correctly when running the development server.

This resolves an issue where the server would fail to start due to the `DATABASE_URL` environment variable not being set.